### PR TITLE
bugfix app crash when press ESC during screencapture

### DIFF
--- a/standalone_app/Snap2LaTeX.py
+++ b/standalone_app/Snap2LaTeX.py
@@ -193,7 +193,11 @@ if __name__ == "__main__":
         # set the qicon to a processing icon
         tray.setIcon(icon_inproc)
 
-        QTimer.singleShot(1, lambda: analyze_image(temp_file, temp_dir))
+        if os.path.exists(temp_file):
+            QTimer.singleShot(1, lambda: analyze_image(temp_file, temp_dir))
+        else:
+            os.rmdir(temp_dir)
+            tray.setIcon(icon)
 
     # Create the menu
     menu = QMenu()


### PR DESCRIPTION
bug reproduce:
① Firstly open Snap2LaTeX menu, click 'Capture' button, and a crosshair cursor for screenshot will appear.
② However, do not actually take a screenshot, but press ESC to exit. At this point, the program will pop out the error dialog, then crash.